### PR TITLE
Fix Nederwoon scraping bug when href missing

### DIFF
--- a/main.py
+++ b/main.py
@@ -179,6 +179,8 @@ class NederwoonScraper(BaseScraper):
                     continue
                 title = a_elem.get_text(strip=True)
                 relative_url = a_elem.get("href", "")
+                if not relative_url:
+                    continue
                 url = relative_url if relative_url.startswith("http") else "https://www.nederwoon.nl" + relative_url
                 address_elem = second_col.find("p", class_="color-medium fixed-lh")
                 address = address_elem.get_text(strip=True) if address_elem else "Address not specified"

--- a/tests/test_nederwoon.py
+++ b/tests/test_nederwoon.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import pytest
+from bs4 import BeautifulSoup
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from main import NederwoonScraper
+
+# HTML snippet with one listing missing href and one valid listing
+HTML = '''
+<div id="locations">
+  <div class="location">
+    <div class="col-lg-4 col-md-3 click-see-page-button">
+      <h2 class="heading-sm"><a class="see-page-button" href="">No URL</a></h2>
+      <p class="color-medium fixed-lh">Bad Address</p>
+    </div>
+    <div class="col-lg-4 col-md-3 vertical-items start-items click-see-page-button">
+      <p class="heading-md text-regular color-primary">€1,000</p>
+    </div>
+  </div>
+  <div class="location">
+    <div class="col-lg-4 col-md-3 click-see-page-button">
+      <h2 class="heading-sm"><a class="see-page-button" href="/valid-path">Valid Listing</a></h2>
+      <p class="color-medium fixed-lh">Valid Address</p>
+    </div>
+    <div class="col-lg-4 col-md-3 vertical-items start-items click-see-page-button">
+      <p class="heading-md text-regular color-primary">€1,500</p>
+    </div>
+  </div>
+</div>
+'''
+
+def test_skip_listing_without_href():
+    scraper = NederwoonScraper('http://example.com', source='Nederwoon')
+    soup = BeautifulSoup(HTML, 'html.parser')
+    listings = scraper.parse_listings(soup)
+    assert len(listings) == 1
+    assert listings[0]['url'] == 'https://www.nederwoon.nl/valid-path'
+


### PR DESCRIPTION
## Summary
- improve the regression test for Nederwoon scraping

## Testing
- `python -m py_compile main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68415acb89048326bb42319417b0c4c6