### PR TITLE
Fix workflow name, revert schedule

### DIFF
--- a/.github/workflows/run-bot.yml
+++ b/.github/workflows/run-bot.yml
@@ -1,4 +1,4 @@
-name: Run Rental Bot Every 5 Minutes
+name: Run Rental Bot
 
 on:
   # This runs on a cron schedule: every 5 minutes


### PR DESCRIPTION
## Summary
- rename rental bot workflow
- restore original cron schedule

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6841638ef9fc8326bcb5970cf0e24088