### PR TITLE
Add persistence test for ListingStorage

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -15,3 +15,15 @@ def test_is_new_and_mark(tmp_path):
     storage.mark_as_seen(test_id)
     assert storage.is_new_listing(test_id) is False
 
+
+
+
+def test_update_with_listings_persist(tmp_path):
+    storage_file = tmp_path / "listings.json"
+    storage_file.write_text("[]")
+    storage = ListingStorage(str(storage_file))
+    listing = {"id": "xyz123"}
+    storage.update_with_listings([listing])
+    storage2 = ListingStorage(str(storage_file))
+    assert storage2.is_new_listing(listing["id"]) is False
+    assert listing["id"] in storage_file.read_text()


### PR DESCRIPTION
## Summary
- expand storage tests to verify persistence across ListingStorage instances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d1e1797c8326bcb22a3a3c536a84